### PR TITLE
Fix API key validation in ipapiis handler

### DIFF
--- a/api/ipapiis.js
+++ b/api/ipapiis.js
@@ -21,7 +21,10 @@ export default (req, res) => {
         return res.status(400).json({ error: 'Invalid IP address' });
     }
 
-    const keys = (process.env.IPAPIIS_API_KEY).split(',');
+    const keys = (process.env.IPAPIIS_API_KEY || '').split(',').filter(Boolean);
+    if (keys.length === 0) {
+        return res.status(500).json({ error: 'API key is missing' });
+    }
     const key = keys[Math.floor(Math.random() * keys.length)];
     const url = `https://api.ipapi.is?q=${ipAddress}&key=${key}`;
 


### PR DESCRIPTION
## Summary
- handle missing `IPAPIIS_API_KEY` env variable in `ipapiis.js`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ef31ebbc8326b8532b69b8e4916b